### PR TITLE
feat: Adds alternate RSS feed link to head

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -8,6 +8,10 @@
 
   <link rel="icon" type="image/x-icon" href="{{ .Site.BaseURL }}favicon.ico">
 
+  {{ with .OutputFormats.Get "rss" -}}
+    {{ printf `<link rel=%q type=%q href=%q title=%q>` .Rel .MediaType.Type .Permalink site.Title | safeHTML }}
+  {{ end }}
+
   {{ if .IsTranslated }}
     {{ range .Translations }}
     <link rel="alternate" hreflang="{{ .Language.LanguageCode }}" href="{{ .Permalink }}" title="{{ .Language.LanguageName }}" />


### PR DESCRIPTION
Turned out not to be a button but a RSS feed reference as in https://gohugo.io/templates/rss/.
This gets automatically read by any feed reader and more "automagic".